### PR TITLE
Fix ServerRequest header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,10 @@
         "psr-4": {
             "Runtime\\SwooleNyholm\\Tests\\": "tests/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "symfony/runtime": true
+        }
     }
 }

--- a/src/RequestHandlerRunner.php
+++ b/src/RequestHandlerRunner.php
@@ -39,7 +39,7 @@ class RequestHandlerRunner implements RunnerInterface
         $psrRequest = (new \Nyholm\Psr7\ServerRequest(
             $request->getMethod(),
             $request->server['request_uri'] ?? '/',
-            array_change_key_case($request->server ?? [], CASE_UPPER),
+            $request->header ?? [],
             $request->rawContent(),
             '1.1',
             $request->server ?? []


### PR DESCRIPTION
When using app with PSR7, heades are not correctly set from `Swoole\Http\Request` to `\Nyholm\Psr7\ServerRequest`